### PR TITLE
fix: resolve changeset validation errors

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,7 +9,9 @@
   "updateInternalDependencies": "patch",
   "ignore": [
     "@gtalumni-la/eslint",
-    "@gtalumni-la/typescript"
+    "@gtalumni-la/typescript",
+    "@gtalumni-la/docs",
+    "@gtalumni-la/storybook"
   ],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true


### PR DESCRIPTION
## Summary
- Fix changeset validation errors by adding docs and storybook packages to ignore list
- Prevents validation errors when packages depend on ignored eslint and typescript configs

## Problem
The release workflow was failing with changeset validation errors because:
- `@gtalumni-la/eslint` and `@gtalumni-la/typescript` are in the ignore list
- Other packages (`@gtalumni-la/docs`, `@gtalumni-la/storybook`, `@gtalumni-la/react`, `@gtalumni-la/tokens`) depend on them
- Changesets requires that if a package depends on an ignored package, it must also be ignored

## Solution
Added `@gtalumni-la/docs` and `@gtalumni-la/storybook` to the changeset ignore list since:
- These are deployment/documentation packages that don't need versioned releases
- They naturally depend on the development configuration packages
- The core packages (`@gtalumni-la/react`, `@gtalumni-la/tokens`) should remain versioned as they are the actual library packages

## Test plan
- [ ] Verify release workflow no longer fails with changeset validation errors
- [ ] Confirm that only core library packages are versioned in releases

🤖 Generated with [Claude Code](https://claude.ai/code)