### PR TITLE
fix: allow eslint and typescript packages to be versioned

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,8 +8,6 @@
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [
-    "@gtalumni-la/eslint",
-    "@gtalumni-la/typescript",
     "@gtalumni-la/docs",
     "@gtalumni-la/storybook"
   ],


### PR DESCRIPTION
## Summary
- Remove eslint and typescript packages from changeset ignore list
- Allow these configuration packages to be properly versioned
- Keep only docs and storybook packages ignored as they are deployment-only

## Problem
The previous fix added all dependent packages to the ignore list, but this created new validation errors because the core packages (`@gtalumni-la/react` and `@gtalumni-la/tokens`) also depend on the eslint and typescript config packages.

The changeset validation was failing with:
```
The package "@gtalumni-la/react" depends on the ignored package "@gtalumni-la/eslint"
The package "@gtalumni-la/tokens" depends on the ignored package "@gtalumni-la/eslint"
The package "@gtalumni-la/react" depends on the ignored package "@gtalumni-la/typescript"
The package "@gtalumni-la/tokens" depends on the ignored package "@gtalumni-la/typescript"
```

## Solution
Instead of ignoring the eslint and typescript config packages, allow them to be versioned normally. This makes sense because:

1. **Configuration packages should be versioned**: ESLint and TypeScript configs can have breaking changes that need semantic versioning
2. **Simpler dependency graph**: No complex ignore rules needed
3. **Proper versioning**: All library packages (`react`, `tokens`, `eslint`, `typescript`) get versioned together
4. **Only deployment packages ignored**: Only `docs` and `storybook` remain ignored since they are deployment artifacts

## Test plan
- [x] Verify `pnpm changeset status` passes without validation errors
- [ ] Confirm release workflow completes successfully
- [ ] Check that all core packages can be versioned together

🤖 Generated with [Claude Code](https://claude.ai/code)