### PR TITLE
docs: add documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ An atomic design system for the Georgia Tech community, providing a consistent a
 [![npm version](https://badge.fury.io/js/%40gtalumni-la%2Ftokens.svg)](https://badge.fury.io/js/%40gtalumni-la%2Ftokens)
 [![npm version](https://badge.fury.io/js/%40gtalumni-la%2Freact.svg)](https://badge.fury.io/js/%40gtalumni-la%2Freact)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Documentation](https://img.shields.io/badge/docs-live-blue.svg)](https://gtalumni-la.github.io/gt-design-system/)
 
 Built with pnpm workspaces and Turborepo for the Georgia Tech Alumni community.
 


### PR DESCRIPTION
## Summary
- Add documentation badge linking to live documentation site
- Makes it easier for users to find the documentation
- Small change to trigger main branch documentation deployment

## Purpose
This change serves two purposes:
1. **User Experience**: Adds a helpful badge for users to quickly access documentation
2. **System Maintenance**: Triggers the main branch documentation deployment workflow

## Preview
The badge will appear as: [\![Documentation](https://img.shields.io/badge/docs-live-blue.svg)](https://gtalumni-la.github.io/gt-design-system/)

🤖 Generated with [Claude Code](https://claude.ai/code)