### PR TITLE
fix: preserve preview directories in main documentation deployment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -68,25 +68,29 @@ jobs:
           # Check out existing gh-pages branch to preserve preview directories
           if git ls-remote --exit-code --heads origin gh-pages > /dev/null 2>&1; then
             echo "Fetching existing gh-pages branch to preserve previews..."
-            git fetch origin gh-pages:gh-pages 2>/dev/null || true
-            git checkout gh-pages 2>/dev/null || true
-            
-            # Copy existing preview directories and manifests
-            if [ -d "preview" ]; then
-              echo "Preserving existing preview directories..."
-              cp -r preview/ dist/
+            if ! git fetch origin gh-pages:gh-pages 2>/dev/null; then
+              echo "Warning: Failed to fetch gh-pages branch from origin." >&2
             fi
-            if [ -f "previews.json" ]; then
-              echo "Preserving existing previews manifest..."
-              cp previews.json dist/
+            if ! git checkout gh-pages 2>/dev/null; then
+              echo "Warning: Failed to checkout gh-pages branch. Continuing without preserving previews." >&2
+            else
+              # Copy existing preview directories and manifests
+              if [ -d "preview" ]; then
+                echo "Preserving existing preview directories..."
+                cp -r preview/ dist/
+              fi
+              if [ -f "previews.json" ]; then
+                echo "Preserving existing previews manifest..."
+                cp previews.json dist/
+              fi
+              if [ -f "versions.json" ]; then
+                echo "Preserving existing versions manifest..."
+                cp versions.json dist/
+              fi
+              
+              # Switch back to main branch content
+              git checkout main
             fi
-            if [ -f "versions.json" ]; then
-              echo "Preserving existing versions manifest..."
-              cp versions.json dist/
-            fi
-            
-            # Switch back to main branch content
-            git checkout -
           fi
           
           # Copy VitePress build (main site) - this will overwrite root files but preserve preview/

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -65,7 +65,31 @@ jobs:
         run: |
           mkdir -p dist
           
-          # Copy VitePress build (main site)
+          # Check out existing gh-pages branch to preserve preview directories
+          if git ls-remote --exit-code --heads origin gh-pages > /dev/null 2>&1; then
+            echo "Fetching existing gh-pages branch to preserve previews..."
+            git fetch origin gh-pages:gh-pages 2>/dev/null || true
+            git checkout gh-pages 2>/dev/null || true
+            
+            # Copy existing preview directories and manifests
+            if [ -d "preview" ]; then
+              echo "Preserving existing preview directories..."
+              cp -r preview/ dist/
+            fi
+            if [ -f "previews.json" ]; then
+              echo "Preserving existing previews manifest..."
+              cp previews.json dist/
+            fi
+            if [ -f "versions.json" ]; then
+              echo "Preserving existing versions manifest..."
+              cp versions.json dist/
+            fi
+            
+            # Switch back to main branch content
+            git checkout -
+          fi
+          
+          # Copy VitePress build (main site) - this will overwrite root files but preserve preview/
           cp -r apps/docs/.vitepress/dist/* dist/
           
           # Copy Storybook build
@@ -77,19 +101,16 @@ jobs:
             exit 1
           fi
           
-          # Fetch available versions from gh-pages branch (if it exists)
-          # This will help populate the version switcher
-          if git ls-remote --exit-code --heads origin gh-pages > /dev/null 2>&1; then
-            echo "Fetching version information from gh-pages branch..."
-            git fetch origin gh-pages:gh-pages 2>/dev/null || true
-            if git show gh-pages:versions.json > /dev/null 2>&1; then
-              git show gh-pages:versions.json > dist/versions.json 2>/dev/null || echo '{"current": {"version": "${{ steps.version.outputs.version }}", "path": "/", "label": "${{ steps.version.outputs.version }} (latest)"}, "versions": []}' > dist/versions.json
-            else
-              echo '{"current": {"version": "${{ steps.version.outputs.version }}", "path": "/", "label": "${{ steps.version.outputs.version }} (latest)"}, "versions": []}' > dist/versions.json
-            fi
-          else
-            echo "No gh-pages branch found, creating default versions.json"
+          # Create or update versions.json if it doesn't exist
+          if [ ! -f "dist/versions.json" ]; then
+            echo "Creating default versions.json"
             echo '{"current": {"version": "${{ steps.version.outputs.version }}", "path": "/", "label": "${{ steps.version.outputs.version }} (latest)"}, "versions": []}' > dist/versions.json
+          fi
+          
+          # Create default previews.json if it doesn't exist
+          if [ ! -f "dist/previews.json" ]; then
+            echo "Creating default previews.json"
+            echo '{"previews": []}' > dist/previews.json
           fi
 
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- Fix deploy-docs workflow to preserve preview directories during main site deployment
- Prevent preview URLs from returning 404 after main branch deployments
- Ensure both main documentation and preview deployments coexist properly

## Problem
The current deploy-docs workflow uses GitHub's `actions/deploy-pages@v4` which completely replaces the gh-pages branch content. This means:

1. **Preview deployments work initially** - The deploy-preview workflow creates preview directories successfully
2. **Main deployment wipes previews** - When deploy-docs runs, it replaces the entire gh-pages branch, deleting all preview directories
3. **Preview URLs return 404** - Users get 404 errors when accessing preview URLs after main deployments

## Root Cause
The `actions/deploy-pages@v4` action performs a complete replacement of the gh-pages branch rather than an incremental update, which is incompatible with having both main docs and preview subdirectories.

## Solution
Modified the deploy-docs workflow to:

1. **Preserve existing content**: Check out the current gh-pages branch before deployment
2. **Copy preview directories**: Preserve the `preview/` directory and manifests (`previews.json`, `versions.json`)
3. **Deploy main site alongside previews**: Copy main documentation files while keeping preview directories intact
4. **Maintain manifests**: Ensure preview and version tracking files are preserved

## Changes Made

### `.github/workflows/deploy-docs.yml`
- Added gh-pages branch checkout before deployment
- Added preservation of `preview/` directory, `previews.json`, and `versions.json`
- Modified deployment preparation to work incrementally rather than replacing everything
- Added fallback creation of manifest files if they don't exist

## Test Plan
- [x] Verify main documentation site loads correctly at root URL
- [ ] Verify existing preview directories are preserved after main deployment  
- [ ] Test that preview URLs work correctly after main site deployment
- [ ] Confirm new previews can be created after main deployment
- [ ] Check that version and preview manifests are maintained

## Expected Result
After this fix:
- ✅ Main documentation: `https://gtalumni-la.github.io/gt-design-system/` 
- ✅ Preview sites: `https://gtalumni-la.github.io/gt-design-system/preview/pr-50/`
- ✅ Storybook previews: `https://gtalumni-la.github.io/gt-design-system/preview/pr-50/storybook/`

🤖 Generated with [Claude Code](https://claude.ai/code)