### PR TITLE
fix: configure storybook base path for github pages deployment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -47,6 +47,8 @@ jobs:
 
       - name: Build Storybook
         run: pnpm --filter @gtalumni-la/storybook build
+        env:
+          GITHUB_PAGES: true
 
       - name: Build VitePress documentation
         run: pnpm --filter @gtalumni-la/docs build

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -34,6 +34,24 @@ const config: StorybookConfig = {
   core: {
     disableTelemetry: true,
   },
+  managerHead: (head) => {
+    // Set base href for GitHub Pages deployment
+    if (process.env.GITHUB_ACTIONS === 'true' || process.env.GITHUB_PAGES === 'true') {
+      return `
+        ${head}
+        <base href="/storybook/">
+      `;
+    }
+    return head;
+  },
+  viteFinal: (config) => {
+    // Set base path for GitHub Pages deployment
+    // Check for GitHub Actions environment or explicit GITHUB_PAGES flag
+    if (process.env.GITHUB_ACTIONS === 'true' || process.env.GITHUB_PAGES === 'true') {
+      config.base = '/storybook/';
+    }
+    return config;
+  },
 };
 
 export default config;


### PR DESCRIPTION
## Summary

Fixes Storybook deployment on GitHub Pages by configuring the correct base path for asset resolution.

## Changes Made

- **Storybook Configuration**: Added `managerHead` hook to inject `<base href="/storybook/">` tag
- **Vite Configuration**: Set `config.base = '/storybook/'` when deploying to GitHub Pages  
- **GitHub Actions**: Added `GITHUB_PAGES=true` environment variable to Storybook build step
- **Environment Detection**: Only applies base path configuration when building for GitHub Pages

## Problem Solved

When Storybook is deployed to GitHub Pages at `/storybook/` subdirectory, all assets (CSS, JS, fonts) fail to load because they use relative paths that resolve incorrectly. This fix ensures:

- ✅ Assets load from correct `/storybook/assets/` paths
- ✅ Navigation and routing work properly
- ✅ Iframe content displays correctly
- ✅ Development builds remain unaffected

## Test Plan

- [x] Local build with `GITHUB_PAGES=true` generates correct `<base href="/storybook/">` tag
- [x] Local build without environment variable works normally
- [ ] Verify GitHub Pages deployment loads assets correctly
- [ ] Test Storybook navigation and story rendering

🤖 Generated with [Claude Code](https://claude.ai/code)